### PR TITLE
Audit fix #00

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,12 @@
     "incomplete-features"
   ],
   "rust-analyzer.linkedProjects": [
-    "program/Cargo.toml",
-    "script/Cargo.toml",
+    "host/Cargo.toml",
+    "methods/guest/Cargo.toml",
     "primitives/Cargo.toml"
   ],
-  "rust-analyzer.showUnlinkedFileNotification": false
+  "rust-analyzer.showUnlinkedFileNotification": false,
+  "rust-analyzer.check.extraEnv": {
+    "RISC0_SKIP_BUILD": "1",
+  }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,6 +4720,7 @@ dependencies = [
  "alloy-trie",
  "helios-consensus-core",
  "serde",
+ "serde_cbor",
 ]
 
 [[package]]

--- a/contracts/genesis.json
+++ b/contracts/genesis.json
@@ -1,17 +1,17 @@
 {
-  "executionStateRoot": "0xde1a8741151bbb8274343a73e4b48111e811ae626ff6460daa0b332ba8b18015",
+  "executionStateRoot": "0xc836105879165a191ca365b2af8795a7357854b2fc9dd6c8f308302284893782",
   "genesisTime": 1606824023,
-  "genesisValidatorsRoot": "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
-  "head": 11392832,
-  "header": "0x96c6b2c5986d4a076c8e1be67a78b8294235da1d6ed6f398027da2f5092a5438",
-  "heliosImageId": "0xca57abce574e4c5b08f4164df1322b6b76bf93574393d0fa19e3b0ea2953bd44",
+  "chainCommitment": "0xbac3a613a43f19496d73ba49941cb886ebc6a6a34767f0277a5155f650df817c",
+  "head": 11509312,
+  "header": "0x5b066041028507f6e79550fd6005db7843a5a8feb4aee7a352457fbdbb8bc074",
+  "heliosImageId": "0x203a0dbcc986cfb6f77ceb60e1a8b018aac640b64651eec3111956730e12d997",
   "secondsPerSlot": 12,
   "slotsPerEpoch": 32,
   "slotsPerPeriod": 8192,
   "sourceChainId": 1,
-  "syncCommitteeHash": "0x9e35f333b804a7de871d8c8168d77c163e854fe3c37d611a5a82f8a1bdbbb9f4",
+  "syncCommitteeHash": "0xbfe695f225179ff4ac1d4c3305ef123d6dc7f08f81cacffab4dbec51434efc5a",
   "updaters": [
-    "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   ],
   "verifier": "0x0000000000000000000000000000000000000000"
 }

--- a/contracts/src/R0VMHelios.sol
+++ b/contracts/src/R0VMHelios.sol
@@ -77,6 +77,7 @@ contract R0VMHelios is AccessControlEnumerable {
         uint256 prevHead;
         bytes32 syncCommitteeHash;
         bytes32 startSyncCommitteeHash;
+        bytes32 genesisRoot;
         StorageSlot[] slots;
     }
 
@@ -114,6 +115,7 @@ contract R0VMHelios is AccessControlEnumerable {
     error PreviousHeadNotSet(uint256 slot);
     error PreviousHeadTooOld(uint256 slot);
     error NoUpdatersProvided();
+    error GenesisValidatorsRootMismatch(bytes32 given, bytes32 expected);
 
     /// @notice Initializes the SP1Helios contract with the provided parameters
     /// @dev Sets up immutable contract state and grants the UPDATER_ROLE to the provided updaters
@@ -172,6 +174,9 @@ contract R0VMHelios is AccessControlEnumerable {
         ProofOutputs memory po = abi.decode(journalData, (ProofOutputs));
         if (po.newHead <= fromHead) {
             revert SlotBehindHead(po.newHead);
+        }
+        if (po.genesisRoot != GENESIS_VALIDATORS_ROOT) {
+            revert GenesisValidatorsRootMismatch(po.genesisRoot, GENESIS_VALIDATORS_ROOT);
         }
 
         uint256 currentPeriod = getSyncCommitteePeriod(fromHead);

--- a/contracts/src/R0VMHelios.sol
+++ b/contracts/src/R0VMHelios.sol
@@ -12,8 +12,8 @@ import {AccessControlEnumerable} from
 /// It also provides functionality to verify and store Ethereum storage slot values.
 /// Updater permissions are fixed at contract creation time and cannot be modified afterward.
 contract R0VMHelios is AccessControlEnumerable {
-    /// @notice The genesis validators root for the beacon chain
-    bytes32 public immutable GENESIS_VALIDATORS_ROOT;
+    /// @notice Commitment to the chain, defined as keccak256(genesis_root | cbor::encode(forks))
+    bytes32 public immutable CHAIN_COMMITMENT;
 
     /// @notice The timestamp at which the beacon chain genesis block was processed
     uint256 public immutable GENESIS_TIME;
@@ -77,7 +77,7 @@ contract R0VMHelios is AccessControlEnumerable {
         uint256 prevHead;
         bytes32 syncCommitteeHash;
         bytes32 startSyncCommitteeHash;
-        bytes32 genesisRoot;
+        bytes32 chainCommitment;
         StorageSlot[] slots;
     }
 
@@ -85,7 +85,7 @@ contract R0VMHelios is AccessControlEnumerable {
     struct InitParams {
         bytes32 executionStateRoot;
         uint256 genesisTime;
-        bytes32 genesisValidatorsRoot;
+        bytes32 chainCommitment;
         uint256 head;
         bytes32 header;
         bytes32 heliosImageId;
@@ -115,13 +115,13 @@ contract R0VMHelios is AccessControlEnumerable {
     error PreviousHeadNotSet(uint256 slot);
     error PreviousHeadTooOld(uint256 slot);
     error NoUpdatersProvided();
-    error GenesisValidatorsRootMismatch(bytes32 given, bytes32 expected);
+    error ChainCommitmentMismatch(bytes32 given, bytes32 expected);
 
     /// @notice Initializes the SP1Helios contract with the provided parameters
     /// @dev Sets up immutable contract state and grants the UPDATER_ROLE to the provided updaters
     /// @param params The initialization parameters
     constructor(InitParams memory params) {
-        GENESIS_VALIDATORS_ROOT = params.genesisValidatorsRoot;
+        CHAIN_COMMITMENT = params.chainCommitment;
         GENESIS_TIME = params.genesisTime;
         SECONDS_PER_SLOT = params.secondsPerSlot;
         SLOTS_PER_PERIOD = params.slotsPerPeriod;
@@ -175,8 +175,8 @@ contract R0VMHelios is AccessControlEnumerable {
         if (po.newHead <= fromHead) {
             revert SlotBehindHead(po.newHead);
         }
-        if (po.genesisRoot != GENESIS_VALIDATORS_ROOT) {
-            revert GenesisValidatorsRootMismatch(po.genesisRoot, GENESIS_VALIDATORS_ROOT);
+        if (po.chainCommitment != CHAIN_COMMITMENT) {
+            revert ChainCommitmentMismatch(po.chainCommitment, CHAIN_COMMITMENT);
         }
 
         uint256 currentPeriod = getSyncCommitteePeriod(fromHead);

--- a/contracts/test/R0VMHelios.t.sol
+++ b/contracts/test/R0VMHelios.t.sol
@@ -136,6 +136,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
 
@@ -202,6 +203,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
         bytes memory publicValues = abi.encode(po);
@@ -260,6 +262,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: syncCommitteeHash,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
 
@@ -319,6 +322,7 @@ contract R0VMHeliosTest is Test {
             prevHead: nonExistentHead,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: bytes32(0),
+            genesisRoot: bytes32(0),
             slots: slots
         });
 
@@ -347,6 +351,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
 
@@ -374,6 +379,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
 
@@ -402,6 +408,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: wrongSyncCommitteeHash, // Wrong hash
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
 
@@ -417,6 +424,41 @@ contract R0VMHeliosTest is Test {
                 R0VMHelios.SyncCommitteeStartMismatch.selector,
                 wrongSyncCommitteeHash,
                 INITIAL_SYNC_COMMITTEE_HASH
+            )
+        );
+        helios.update(proof, publicValues, INITIAL_HEAD);
+    }
+
+    function testUpdateWithGenesisRootMismatch() public {
+        R0VMHelios.StorageSlot[] memory slots = new R0VMHelios.StorageSlot[](0); // No storage slots for this test
+
+        bytes32 wrongGenesisRoot = bytes32(uint256(999));
+
+        R0VMHelios.ProofOutputs memory po = R0VMHelios.ProofOutputs({
+            executionStateRoot: bytes32(0),
+            newHeader: bytes32(0),
+            nextSyncCommitteeHash: bytes32(0),
+            newHead: INITIAL_HEAD + 1,
+            prevHeader: INITIAL_HEADER,
+            prevHead: INITIAL_HEAD,
+            syncCommitteeHash: bytes32(0),
+            startSyncCommitteeHash: bytes32(0),
+            genesisRoot: wrongGenesisRoot, // Mismatch with the initial setup
+            slots: slots
+        });
+
+        bytes memory publicValues = abi.encode(po);
+        bytes memory proof = new bytes(0);
+
+        // Set block timestamp to be valid for the update
+        vm.warp(helios.slotTimestamp(INITIAL_HEAD) + 1 hours);
+
+        vm.prank(initialUpdater);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                R0VMHelios.GenesisValidatorsRootMismatch.selector,
+                wrongGenesisRoot,
+                GENESIS_VALIDATORS_ROOT
             )
         );
         helios.update(proof, publicValues, INITIAL_HEAD);
@@ -440,6 +482,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: slots
         });
         bytes memory publicValues = abi.encode(po);
@@ -578,6 +621,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: emptySlots
         });
 
@@ -629,6 +673,7 @@ contract R0VMHeliosTest is Test {
             prevHead: prevHead,
             syncCommitteeHash: newSyncCommitteeHash,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH, // This must match the sync committee from the initial setup
+            genesisRoot: GENESIS_VALIDATORS_ROOT,
             slots: emptySlots
         });
 

--- a/contracts/test/R0VMHelios.t.sol
+++ b/contracts/test/R0VMHelios.t.sol
@@ -14,7 +14,7 @@ contract R0VMHeliosTest is Test {
     address initialUpdater = address(0x2);
 
     // Constants for test setup
-    bytes32 constant GENESIS_VALIDATORS_ROOT = bytes32(uint256(1));
+    bytes32 constant CHAIN_COMMITMENT = bytes32(uint256(1));
     uint256 constant GENESIS_TIME = 1606824023; // Dec 1, 2020
     uint256 constant SECONDS_PER_SLOT = 12;
     uint256 constant SLOTS_PER_EPOCH = 32;
@@ -36,7 +36,7 @@ contract R0VMHeliosTest is Test {
         R0VMHelios.InitParams memory params = R0VMHelios.InitParams({
             executionStateRoot: INITIAL_EXECUTION_STATE_ROOT,
             genesisTime: GENESIS_TIME,
-            genesisValidatorsRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             head: INITIAL_HEAD,
             header: INITIAL_HEADER,
             heliosImageId: HELIOS_IMAGE_ID,
@@ -53,7 +53,7 @@ contract R0VMHeliosTest is Test {
     }
 
     function testInitialization() public view {
-        assertEq(helios.GENESIS_VALIDATORS_ROOT(), GENESIS_VALIDATORS_ROOT);
+        assertEq(helios.CHAIN_COMMITMENT(), CHAIN_COMMITMENT);
         assertEq(helios.GENESIS_TIME(), GENESIS_TIME);
         assertEq(helios.SECONDS_PER_SLOT(), SECONDS_PER_SLOT);
         assertEq(helios.SLOTS_PER_EPOCH(), SLOTS_PER_EPOCH);
@@ -136,7 +136,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
 
@@ -169,7 +169,7 @@ contract R0VMHeliosTest is Test {
         R0VMHelios.InitParams memory params = R0VMHelios.InitParams({
             executionStateRoot: INITIAL_EXECUTION_STATE_ROOT,
             genesisTime: GENESIS_TIME,
-            genesisValidatorsRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             head: INITIAL_HEAD,
             header: INITIAL_HEADER,
             heliosImageId: HELIOS_IMAGE_ID,
@@ -203,7 +203,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
         bytes memory publicValues = abi.encode(po);
@@ -262,7 +262,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: syncCommitteeHash,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
 
@@ -322,7 +322,7 @@ contract R0VMHeliosTest is Test {
             prevHead: nonExistentHead,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: bytes32(0),
-            genesisRoot: bytes32(0),
+            chainCommitment: bytes32(0),
             slots: slots
         });
 
@@ -351,7 +351,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
 
@@ -379,7 +379,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
 
@@ -408,7 +408,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: wrongSyncCommitteeHash, // Wrong hash
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
 
@@ -429,10 +429,10 @@ contract R0VMHeliosTest is Test {
         helios.update(proof, publicValues, INITIAL_HEAD);
     }
 
-    function testUpdateWithGenesisRootMismatch() public {
+    function testUpdateWithChainCommitmentMismatch() public {
         R0VMHelios.StorageSlot[] memory slots = new R0VMHelios.StorageSlot[](0); // No storage slots for this test
 
-        bytes32 wrongGenesisRoot = bytes32(uint256(999));
+        bytes32 wrongchainCommitment = bytes32(uint256(999));
 
         R0VMHelios.ProofOutputs memory po = R0VMHelios.ProofOutputs({
             executionStateRoot: bytes32(0),
@@ -443,7 +443,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: bytes32(0),
             startSyncCommitteeHash: bytes32(0),
-            genesisRoot: wrongGenesisRoot, // Mismatch with the initial setup
+            chainCommitment: wrongchainCommitment, // Mismatch with the initial setup
             slots: slots
         });
 
@@ -456,9 +456,9 @@ contract R0VMHeliosTest is Test {
         vm.prank(initialUpdater);
         vm.expectRevert(
             abi.encodeWithSelector(
-                R0VMHelios.GenesisValidatorsRootMismatch.selector,
-                wrongGenesisRoot,
-                GENESIS_VALIDATORS_ROOT
+                R0VMHelios.ChainCommitmentMismatch.selector,
+                wrongchainCommitment,
+                CHAIN_COMMITMENT
             )
         );
         helios.update(proof, publicValues, INITIAL_HEAD);
@@ -482,7 +482,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: slots
         });
         bytes memory publicValues = abi.encode(po);
@@ -503,7 +503,7 @@ contract R0VMHeliosTest is Test {
         R0VMHelios.InitParams memory params = R0VMHelios.InitParams({
             executionStateRoot: INITIAL_EXECUTION_STATE_ROOT,
             genesisTime: GENESIS_TIME,
-            genesisValidatorsRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             head: INITIAL_HEAD,
             header: INITIAL_HEADER,
             heliosImageId: HELIOS_IMAGE_ID,
@@ -534,7 +534,7 @@ contract R0VMHeliosTest is Test {
         R0VMHelios.InitParams memory params = R0VMHelios.InitParams({
             executionStateRoot: INITIAL_EXECUTION_STATE_ROOT,
             genesisTime: GENESIS_TIME,
-            genesisValidatorsRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             head: INITIAL_HEAD,
             header: INITIAL_HEADER,
             heliosImageId: HELIOS_IMAGE_ID,
@@ -621,7 +621,7 @@ contract R0VMHeliosTest is Test {
             prevHead: INITIAL_HEAD,
             syncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH,
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: emptySlots
         });
 
@@ -673,7 +673,7 @@ contract R0VMHeliosTest is Test {
             prevHead: prevHead,
             syncCommitteeHash: newSyncCommitteeHash,
             startSyncCommitteeHash: INITIAL_SYNC_COMMITTEE_HASH, // This must match the sync committee from the initial setup
-            genesisRoot: GENESIS_VALIDATORS_ROOT,
+            chainCommitment: CHAIN_COMMITMENT,
             slots: emptySlots
         });
 

--- a/host/bin/genesis.rs
+++ b/host/bin/genesis.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 /// Generate genesis parameters for light client contract
 use clap::Parser;
 use r0vm_helios_methods::R0VM_HELIOS_GUEST_ID;
+use r0vm_helios_primitives::utils::compute_chain_commitment;
 use r0vm_helios_script::{get_checkpoint, get_client, get_latest_checkpoint};
 use risc0_zkvm::Digest;
 use serde::{Deserialize, Serialize};
@@ -27,7 +28,7 @@ pub struct GenesisArgs {
 pub struct GenesisConfig {
     pub execution_state_root: String,
     pub genesis_time: u64,
-    pub genesis_validators_root: String,
+    pub chain_commitment: String,
     pub head: u64,
     pub header: String,
     pub helios_image_id: String,
@@ -99,7 +100,10 @@ pub async fn main() -> Result<()> {
     // Read the Genesis config from the contracts directory.
     let mut genesis_config = get_existing_genesis_config(&workspace_root)?;
 
-    genesis_config.genesis_validators_root = format!("0x{:x}", genesis_root);
+    genesis_config.chain_commitment = format!(
+        "0x{:x}",
+        compute_chain_commitment(genesis_root, &helios_client.config.forks)?
+    );
     genesis_config.genesis_time = genesis_time;
     genesis_config.seconds_per_slot = SECONDS_PER_SLOT;
     genesis_config.slots_per_period = SLOTS_PER_PERIOD;

--- a/host/bin/operator.rs
+++ b/host/bin/operator.rs
@@ -172,12 +172,7 @@ impl R0VMHeliosOperator {
             store: client.store.clone(),
             genesis_root: client.config.chain.genesis_root,
             forks: client.config.forks.clone(),
-            contract_storage_slots: ContractStorage {
-                address: todo!(),
-                expected_value: todo!(),
-                mpt_proof: todo!(),
-                storage_slots: todo!(),
-            },
+            contract_storage_slots: ContractStorage::default(),
         };
         let encoded_proof_inputs = serde_cbor::to_vec(&inputs)?;
 

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -3363,6 +3363,7 @@ dependencies = [
  "alloy-trie",
  "helios-consensus-core",
  "serde",
+ "serde_cbor",
 ]
 
 [[package]]

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -7,8 +7,9 @@ use alloy_trie::{proof, Nibbles};
 use helios_consensus_core::{
     apply_finality_update, apply_update, verify_finality_update, verify_update,
 };
-use r0vm_helios_primitives::types::{
-    ContractStorage, ProofInputs, ProofOutputs, VerifiedStorageSlot,
+use r0vm_helios_primitives::{
+    types::{ContractStorage, ProofInputs, ProofOutputs, VerifiedStorageSlot},
+    utils::compute_chain_commitment,
 };
 use risc0_zkvm::guest::env;
 use tree_hash::TreeHash;
@@ -99,7 +100,7 @@ pub fn main() {
         prevHead: U256::from(prev_head),
         syncCommitteeHash: sync_committee_hash,
         startSyncCommitteeHash: start_sync_committee_hash,
-        genesisRoot: genesis_root,
+        chainCommitment: compute_chain_commitment(genesis_root, &forks).unwrap(),
         slots: verified_slots,
     };
     env::commit_slice(&proof_outputs.abi_encode());

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -7,10 +7,10 @@ use alloy_trie::{proof, Nibbles};
 use helios_consensus_core::{
     apply_finality_update, apply_update, verify_finality_update, verify_update,
 };
-use risc0_zkvm::guest::env;
 use r0vm_helios_primitives::types::{
     ContractStorage, ProofInputs, ProofOutputs, VerifiedStorageSlot,
 };
+use risc0_zkvm::guest::env;
 use tree_hash::TreeHash;
 
 risc0_zkvm::guest::entry!(main);
@@ -99,6 +99,7 @@ pub fn main() {
         prevHead: U256::from(prev_head),
         syncCommitteeHash: sync_committee_hash,
         startSyncCommitteeHash: start_sync_committee_hash,
+        genesisRoot: genesis_root,
         slots: verified_slots,
     };
     env::commit_slice(&proof_outputs.abi_encode());

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -11,3 +11,4 @@ helios-consensus-core = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-trie = { workspace = true }
+serde_cbor.workspace = true

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod types;
+pub mod utils;

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -57,6 +57,7 @@ sol! {
         uint256 prevHead;
         bytes32 syncCommitteeHash;
         bytes32 startSyncCommitteeHash;
+        bytes32 genesisRoot;
         VerifiedStorageSlot[] slots;
     }
 }

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -13,7 +13,7 @@ pub struct StorageSlot {
     pub mpt_proof: Vec<Bytes>, // contract-specific MPT proof
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct ContractStorage {
     pub address: Address,
     pub expected_value: TrieAccount,
@@ -57,7 +57,7 @@ sol! {
         uint256 prevHead;
         bytes32 syncCommitteeHash;
         bytes32 startSyncCommitteeHash;
-        bytes32 genesisRoot;
+        bytes32 chainCommitment;
         VerifiedStorageSlot[] slots;
     }
 }

--- a/primitives/src/utils.rs
+++ b/primitives/src/utils.rs
@@ -1,0 +1,11 @@
+use alloy_primitives::{keccak256, B256};
+use helios_consensus_core::types::Forks;
+
+pub fn compute_chain_commitment(
+    genesis_root: B256,
+    forks: &Forks,
+) -> Result<B256, serde_cbor::Error> {
+    Ok(keccak256(
+        [genesis_root.as_slice(), &serde_cbor::to_vec(forks)?].concat(),
+    ))
+}


### PR DESCRIPTION
Address the issue #00 raised in the audit where the genesis validator root and fork data is unconstrained.

This hashes them together into a single chain commitment which is committed to in the journal and checked against a value set at contract initialization